### PR TITLE
Added GET /api/v1/books/{book_id} endpoint to retrieve book details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official Python image as the base image
+FROM python:3.9-slim
+
+# Set work directory
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+# Copy the application code into the container
+COPY . .
+
+# Expose the port FastAPI will run on (default is 8000)
+EXPOSE 8000
+
+# Run the FastAPI application using Uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -46,6 +46,18 @@ async def create_book(book: Book):
 )
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
+
+
+# New endpoint
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int):
+    book = db.books.get(book_id)
+    if not book:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, 
+            detail="Book not found"
+        )
+    return book
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    container_name: fastapi-app
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    environment:
+      - PYTHONPATH=/app
+
+  nginx:
+    image: nginx:latest
+    container_name: fastapi-nginx
+    ports:
+      - "80:80"
+    depends_on:
+      - app
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Description
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.
- Configured CI pipeline to run tests on pull requests.

## Related Task
[Stage 2 DevOps Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739196873624569)

## Testing
- Ran `pytest` locally and all tests passed.
- Confirmed CI workflow configuration.

## Notes
- Collaborator `hng12-devbotops` has been invited.
- Deployment URL: `http://54.221.113.135:8000/api/v1/books/1`
