### PR TITLE
Added CD Pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: CD Pipeline
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            # Update package index and install dependencies
+            sudo apt-get update -y
+            sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+
+            # Add Docker's official GPG key
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+            # Install Docker
+            sudo apt-get update -y
+            sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+            # Add the SSH user to the Docker group
+            sudo usermod -aG docker ${{ secrets.SSH_USERNAME }}
+
+            # Install Docker Compose
+            sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+
+            # Verify installations
+            docker --version
+            docker-compose --version
+
+            # Navigate to the project directory and deploy
+            cd /home/ubuntu/
+            git clone <your-github-repo>
+            cd fastapi-book-project/
+            git pull
+            docker-compose up -d --build


### PR DESCRIPTION
## Description  
- Added Continuous Deployment (CD) pipeline using GitHub Actions.  
- Configured `deploy` job to deploy the FastAPI application via SSH.  
- The pipeline installs Docker and Docker Compose, builds the Docker container, and runs the application.  

## Related Task  
[[HNG12 Stage 2 Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739196873624569)  

## Testing  
- Verified pipeline runs successfully on push to the `main` branch.  
- Ensured that Docker and Docker Compose are correctly installed on the server.  

## Deployment  
- Deployment triggered on push to the `main` branch.  
- Application is served using Docker and Docker Compose.  

## Notes  
- Ensure `SSH_HOST`, `SSH_USERNAME`, and `SSH_PRIVATE_KEY` secrets are correctly configured in the repository.  
- Deployment server: `http://54.221.113.135:8000/api/v1/books/1` 


